### PR TITLE
fix crash

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -15,7 +15,9 @@ static void *thread_routine (void *arg) { //arg is connected fd
 	int connfd = (long int) arg;
 
 	memset(&inbuf, 0, sizeof(inbuf));
-	recv(connfd, inbuf, sizeof(inbuf), 0);
+	int recvlen=recv(connfd, inbuf, sizeof(inbuf), 0);
+	if(recvlen<=0) 
+		pthread_exit((void *) 0);
 
 	char cpy[512];
 	strcpy(cpy, inbuf);


### PR DESCRIPTION
The cause of server crashing is that  your input buffer might  be empty. In my case, my browser use 
multi port to connect to this http server, but use only one port to transfer data. So when they all begin to finish their connection since not supporting  "http keep-alive" in your code, func recv() will return 0 which means your input buffer is mepty , meanwhile your code miss checking it. strtok() will return null,
then crash happening when you call strcat().

Hope you understanding.
